### PR TITLE
Thumbnail size fix upon insertion

### DIFF
--- a/js/field.js
+++ b/js/field.js
@@ -161,7 +161,7 @@ window.carbon = window.carbon || {};
                 _.each(selections, function(selection) {
                     images.push({
                         'value': selection[valueType],
-                        'url': selection.url
+                        'url': selection.sizes.thumbnail.url
                     });
                 });
 


### PR DESCRIPTION
Initial preview size of images inserted to gallery is “full” instead of
“thumbnail” which makes only the top left corner visible. Suggested
change should fix it by grabbing the URL of a thumbnail.